### PR TITLE
Headless CLI options

### DIFF
--- a/addons/MultiplayCore/MultiPlay.gd
+++ b/addons/MultiplayCore/MultiPlay.gd
@@ -122,6 +122,7 @@ func _ready():
 		return
 	_presetup_nodes()
 	
+	
 	if debug_gui_enabled and OS.is_debug_build():
 		var dgui = preload("res://addons/MultiplayCore/debug_ui/debug_ui.tscn").instantiate()
 		var bootui = dgui.get_node("Layout/BootUI")
@@ -134,6 +135,27 @@ func _ready():
 			bootui.join_address = "127.0.0.1:" + str(port)
 		
 		add_child(dgui)
+	
+	# Parse CLI arguments
+	var arguments = {}
+	for argument in OS.get_cmdline_args():
+		if argument.find("=") > -1:
+			var key_value = argument.split("=")
+			arguments[key_value[0].lstrip("--")] = key_value[1]
+		else:
+			arguments[argument.lstrip("--")] = ""
+	
+	if arguments.has("port"):
+		port = int(arguments.port)
+	
+	if arguments.has("server"):
+		_online_host(arguments.has("act-client"))
+	
+	if arguments.has("client"):
+		var client_url = ""
+		if arguments.has("url"):
+			client_url = arguments.url
+		_online_join(client_url)
 
 func _init_data():
 	print("MultiPlay Core v" + MP_VERSION + " - https://mpc.himaji.xyz - https://discord.gg/PXh9kZ9GzC")


### PR DESCRIPTION
![Screenshot 2024-04-26 230040](https://github.com/maji-git/multiplay-core/assets/150906506/3063404e-205d-4d4b-8d9a-9fc7616a3779)

This allows for hosting the server or joining via command line. Useful for headless server builds.

Arguments list:
- `--server`
- `--port=<port number>`
- `--act-client`
- `--client`
- `--url=<client connect url>`

Server host usage:
```sh
mpc_build.exe --server --port=6942
```