### PR TITLE
MultiPlay Asset Library Registration

### DIFF
--- a/addons/MultiplayCore/MultiPlayTool.gd
+++ b/addons/MultiplayCore/MultiPlayTool.gd
@@ -7,6 +7,8 @@ const UPDATE_POPUP = preload("res://addons/MultiplayCore/editor/window/update_po
 const ICON_RUN = preload("res://addons/MultiplayCore/icons/MPDebugPlay.svg")
 const ICON_RUN_PRESSED = preload("res://addons/MultiplayCore/icons/MPDebugPlay_Pressed.svg")
 
+const MULTIPLAY_ASSETLIB_URL = "https://assets.mpc.himaji.xyz"
+
 var before_export_checkout = null
 var mprun_btn: PanelContainer = null
 
@@ -19,6 +21,7 @@ func _enter_tree():
 	add_autoload_singleton("MPIO", "res://addons/MultiplayCore/MPIO.gd")
 	
 	icon_refresh = get_icon("RotateLeft")
+	_set_assetlib()
 	
 	if FileAccess.file_exists("user://mpc_tool_firstrun"):
 		var fr = FileAccess.open("user://mpc_tool_firstrun", FileAccess.READ)
@@ -41,6 +44,12 @@ func _enter_tree():
 		init_popup.popup_centered()
 		
 		init_popup.confirmed.connect(_firstrun_restart_editor)
+
+func _set_assetlib():
+	var editor_settings = EditorInterface.get_editor_settings()
+	var aburls = editor_settings.get_setting("asset_library/available_urls")
+	
+	aburls["MultiPlay AssetLib"] = MULTIPLAY_ASSETLIB_URL
 
 func _on_project_opened():
 	#mprun_btn = _add_toolbar_button(_mprun_btn, ICON_RUN, ICON_RUN_PRESSED)
@@ -161,7 +170,7 @@ func open_update_popup():
 
 func _exit_tree():
 	remove_tool_menu_item("MultiPlay Core")
-	
+	 
 	remove_export_plugin(before_export_checkout)
 	
 	print("goodbye!")

--- a/addons/MultiplayCore/MultiPlayTool.gd
+++ b/addons/MultiplayCore/MultiPlayTool.gd
@@ -21,7 +21,6 @@ func _enter_tree():
 	add_autoload_singleton("MPIO", "res://addons/MultiplayCore/MPIO.gd")
 	
 	icon_refresh = get_icon("RotateLeft")
-	_set_assetlib()
 	
 	if FileAccess.file_exists("user://mpc_tool_firstrun"):
 		var fr = FileAccess.open("user://mpc_tool_firstrun", FileAccess.READ)
@@ -47,9 +46,15 @@ func _enter_tree():
 
 func _set_assetlib():
 	var editor_settings = EditorInterface.get_editor_settings()
-	var aburls = editor_settings.get_setting("asset_library/available_urls")
+	var aburls: Dictionary = editor_settings.get_setting("asset_library/available_urls")
 	
-	aburls["MultiPlay AssetLib"] = MULTIPLAY_ASSETLIB_URL
+	if !aburls.keys().has("MultiPlay AssetLib"):
+		aburls["MultiPlay AssetLib"] = MULTIPLAY_ASSETLIB_URL
+		
+		print("Installed MultiPlay Asset Library! If you don't see the option in the site dropdown, try to open and close editor settings menu.")
+	else:
+		print("MultiPlay Asset Library has been uninstalled")
+		aburls.erase("MultiPlay AssetLib")
 
 func _on_project_opened():
 	#mprun_btn = _add_toolbar_button(_mprun_btn, ICON_RUN, ICON_RUN_PRESSED)
@@ -58,6 +63,7 @@ func _on_project_opened():
 	var submenu: PopupMenu = PopupMenu.new()
 	submenu.add_item("Check for updates", 1)
 	submenu.add_item("Create Self Signed Certificate", 2)
+	submenu.add_item("Toggle MPC Asset Library", 6)
 	submenu.add_separator()
 	submenu.add_item("Open Documentation", 8)
 	submenu.add_item("Get Support", 9)
@@ -136,6 +142,9 @@ func _toolmenu_pressed(id):
 	
 	if id == 2:
 		run_devscript(preload("res://addons/MultiplayCore/dev_scripts/CertMake.gd"))
+	
+	if id == 6:
+		_set_assetlib()
 	
 	if id == 8:
 		OS.shell_open("https://mpc.himaji.xyz/docs/")

--- a/tests/assets/gdbot/texture/open.png.import
+++ b/tests/assets/gdbot/texture/open.png.import
@@ -4,15 +4,16 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://diovavdu1x8kw"
 path.s3tc="res://.godot/imported/open.png-58b911fa6c76b8d0ff3c791e910a41e4.s3tc.ctex"
+path.etc2="res://.godot/imported/open.png-58b911fa6c76b8d0ff3c791e910a41e4.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://tests/assets/gdbot/texture/open.png"
-dest_files=["res://.godot/imported/open.png-58b911fa6c76b8d0ff3c791e910a41e4.s3tc.ctex"]
+dest_files=["res://.godot/imported/open.png-58b911fa6c76b8d0ff3c791e910a41e4.s3tc.ctex", "res://.godot/imported/open.png-58b911fa6c76b8d0ff3c791e910a41e4.etc2.ctex"]
 
 [params]
 


### PR DESCRIPTION
This pull request introduces MultiPlay Asset Library Registration. MultiPlay Tool will add MultiPlay Asset Library (https://assets.mpc.himaji.xyz/) to the selectable site option in Godot Editor's AssetLib.

MultiPlay Asset Library will be used for extra components, quick patches, and more.

Service Source Code: https://github.com/maji-git/multiplay-assetlib

![Screenshot 2024-05-26 182016](https://github.com/maji-git/multiplay-core/assets/150906506/24683a09-570e-46d8-bef3-6e151cea104d)

