### PR TITLE
[Fix] Scene file mischeck in release builds

### DIFF
--- a/addons/MultiplayCore/MultiPlay.gd
+++ b/addons/MultiplayCore/MultiPlay.gd
@@ -579,11 +579,16 @@ func _check_if_net_from_id(id):
 func _net_load_scene(scene_path: String, respawn_players = true):
 	_net_data.current_scene_path = scene_path
 	
+	var check_scene_path = scene_path
+	
+	if !OS.is_debug_build():
+		check_scene_path = check_scene_path + ".remap"
+	
 	if current_scene:
 		current_scene.queue_free()
 		current_scene = null
 	
-	if !FileAccess.file_exists(scene_path):
+	if !FileAccess.file_exists(check_scene_path):
 		MPIO.logerr("Target scene doesn't exist")
 		return
 	


### PR DESCRIPTION
This pull request addresses https://github.com/maji-git/multiplay-core/issues/8

This pull request fixes scene file checking not working in release builds. Due to Godot release exports adding `.remap` to the end of each scene files. MPC couldn't check for file because of the changed file extension. Now it's fixed by checking for scene file with `.remap` file extension in production builds