### PR TITLE
Fixed project change on startup.

### DIFF
--- a/addons/MultiplayCore/MultiPlayTool.gd
+++ b/addons/MultiplayCore/MultiPlayTool.gd
@@ -20,7 +20,8 @@ func get_icon(n):
 	return EditorInterface.get_base_control().get_theme_icon(n)
 
 func _enter_tree():
-	add_autoload_singleton("MPIO", "res://addons/MultiplayCore/MPIO.gd")
+	if not ProjectSettings.has_setting("autoload/MPIO"):
+		add_autoload_singleton("MPIO", "res://addons/MultiplayCore/MPIO.gd")
 	
 	icon_refresh = get_icon("RotateLeft")
 	


### PR DESCRIPTION
When reopening a project, the history changes will cause the asterisk to appear(*) beside your project name, indicating a change. This fixes that.